### PR TITLE
Implementation of Galactic Plane survey footprint

### DIFF
--- a/footprints/gal_plane_pencilbeams_footprint.py
+++ b/footprints/gal_plane_pencilbeams_footprint.py
@@ -1,0 +1,99 @@
+from rubin_sim.scheduler.utils import Sky_area_generator
+import healpy as hp
+import numpy as np
+from rubin_sim.data import get_data_dir
+from astropy.coordinates import SkyCoord, ICRS, Galactic
+from astropy import units as u
+
+class gal_plane_pencilbeams_generator(Sky_area_generator):
+
+    def add_gal_plane_pencilbeams(self, filter_ratios, radius=6.0,
+                            label='gal_plane_pencilbeams',
+                            field_selection=1):
+
+        temp_map = np.zeros(hp.nside2npix(self.nside))
+
+        # Load list of field centers of pencilbeam fields across the Galactic Plane.
+        # Option 1 corresponds to 20 smaller fields
+        # Option 2 corresponds to 4 larger fields
+        pencilbeams_list = self.load_pencilbeam_fields(field_selection)
+
+        # Generate the map regions from the pencilbeam pointings, using
+        # the field radii given in degrees:
+        for field in pencilbeams_list:
+            pointing = SkyCoord(field['l_center'], field['b_center'], frame=Galactic, unit=(u.deg, u.deg))
+            pointing = pointing.transform_to(ICRS)
+            temp_map += self._set_circular_region(pointing.ra, pointing.dec, field['radius'])
+
+        # Ensure designated pixels are not overriden:
+        indx = np.where((temp_map > 0) & (self.pix_labels == ""))
+        self.pix_labels[indx] = label
+        for filtername in filter_ratios.keys():
+            self.healmaps[filtername][indx] = filter_ratios[filtername]
+
+    def load_pencilbeam_fields(self,field_selection):
+        if field_selection == 1:
+            pencilbeams_list = [
+                {'name': 1, 'l_center': 280.0, 'b_center': 0.0, 'radius': 1.75},
+                {'name': 2, 'l_center': 287.280701754386, 'b_center': 0.0, 'radius': 1.75},
+                {'name': 3, 'l_center': 295.39473684210526, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 4, 'l_center': 306.42543859649123, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 5, 'l_center': 306.2061403508772, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 6, 'l_center': 320.1535087719298, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 7, 'l_center': 324.51754385964915, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 8, 'l_center': 341.38157894736844, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 9, 'l_center': 351.57894736842104, 'b_center':  -2.5, 'radius': 1.75},
+                {'name': 10, 'l_center': 0.10964912280701888, 'b_center':  -2.083333333333333, 'radius': 1.75},
+                {'name': 11, 'l_center': 0.3070175438596484, 'b_center':  -2.083333333333333, 'radius': 1.75},
+                {'name': 12, 'l_center': 8.421052631578945, 'b_center':  -3.333333333333333, 'radius': 1.75},
+                {'name': 13, 'l_center': 17.36842105263159, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 14, 'l_center': 26.31578947368422, 'b_center':  -2.9166666666666665, 'radius': 1.75},
+                {'name': 15, 'l_center': 44.01315789473685, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 16, 'l_center': 44.21052631578948, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 17, 'l_center': 54.40789473684211, 'b_center':  0.0, 'radius': 1.75},
+                {'name': 18, 'l_center': 66.27192982456141, 'b_center':  -0.4166666666666661, 'radius': 1.75},
+                {'name': 19, 'l_center': 71.8859649122807, 'b_center':  0.0, 'radius': 1.75},
+                {'name': 20, 'l_center': 80.0, 'b_center':  -5.0, 'radius': 1.75} ]
+
+        else:
+            pencilbeams_list = [
+                {'name': 1, 'l_center': 306.56, 'b_center': -1.46, 'radius': 3.91},
+                {'name': 2, 'l_center': 331.09, 'b_center': -2.42, 'radius': 3.91},
+                {'name': 3, 'l_center': 18.51, 'b_center': -2.09, 'radius': 3.91},
+                {'name': 4, 'l_center': 26.60, 'b_center': -2.15, 'radius': 3.91} ]
+
+        return pencilbeams_list
+
+    def return_maps(
+        self,
+        magellenic_clouds_ratios={"u": 0.32,"g": 0.4,"r": 1.0,"i": 1.0,"z": 0.9,"y": 0.9,},
+        scp_ratios={"u": 0.1, "g": 0.1, "r": 0.1, "i": 0.1, "z": 0.1, "y": 0.1},
+        nes_ratios={"g": 0.28, "r": 0.4, "i": 0.4, "z": 0.28},
+        dusty_plane_ratios={"u": 0.1,"g": 0.28, "r": 0.28,"i": 0.28,"z": 0.28,"y": 0.1,},
+        low_dust_ratios={"u": 0.32, "g": 0.4, "r": 1.0, "i": 1.0, "z": 0.9, "y": 0.9},
+        bulge_ratios={"u": 0.18, "g": 1.0, "r": 1.05, "i": 1.05, "z": 1.0, "y": 0.23},
+        virgo_ratios={"u": 0.32, "g": 0.4, "r": 1.0, "i": 1.0, "z": 0.9, "y": 0.9},
+
+        pencilbeam_ratios = {"u": 0.18, "g": 1.0, "r": 1.05, "i": 1.05, "z": 1.0, "y": 0.23},
+        ):
+
+        # Array to hold the labels for each pixel
+        self.pix_labels = np.zeros(hp.nside2npix(self.nside), dtype="U20")
+        self.healmaps = np.zeros(
+            hp.nside2npix(self.nside),
+            dtype=list(zip(["u", "g", "r", "i", "z", "y"], [float] * 7)),
+        )
+
+        # Note, order here matters. Once a HEALpix is set and labled, subsequent add_ methods
+        # will not override that pixel.
+        self.add_gal_plane_pencilbeams(pencilbeam_ratios)
+
+        self.add_magellanic_clouds(magellenic_clouds_ratios)
+        self.add_lowdust_wfd(low_dust_ratios)
+        self.add_virgo_cluster(virgo_ratios)
+        self.add_bulge(bulge_ratios)
+        self.add_nes(nes_ratios)
+        self.add_dusty_plane(dusty_plane_ratios)
+        self.add_scp(scp_ratios)
+
+        return self.healmaps, self.pix_labels

--- a/footprints/gal_plane_survey_footprint.py
+++ b/footprints/gal_plane_survey_footprint.py
@@ -1,0 +1,125 @@
+from rubin_sim.scheduler.utils import Sky_area_generator
+import healpy as hp
+import numpy as np
+from rubin_sim.data import get_data_dir
+
+
+class gal_plane_footprint_generator(Sky_area_generator):
+
+    def add_gal_plane_region(self, filter_ratios, radius=6.0, label='gal_plane',
+                            priority_threshold=0.8):
+
+        # This dictionary defines as keys a set of relative priority of pixels
+        # corresponding to thresholds in stellar density; this is used to
+        # select smaller (inc. lower priority pixels) or larger (inc. higher
+        # priority pixels) survey regions
+        priority_thresholds = { 0.8: 0.60, 0.9: 0.70, 1.0: 0.80 }
+        density_threshold[priority_threshold]
+
+        # Load the data on stellar density as a function of sky position.
+        # NOTE: These data are unavoidably in NSIDE=64
+        star_density_map = self.load_star_density_data(limiting_mag=24.7)
+        hp_star_density = self.rotateHealpix(star_density_map)
+        idx = hp_star_density > 0.0
+        hp_log_star_density = np.zeros(len(hp_star_density))
+        hp_log_star_density[idx] = np.log10(hp_star_density[idx])
+
+        # The priority threshold corresponds to a threshold in stellar density,
+        # which is used to identify the HEALpixels of interest for the survey
+        # region.
+        temp_map = np.zeros(len(hp_log_star_density))
+        survey_region_pixels = np.where(hp_log_star_density >= density_threshold*hp_log_star_density.max())[0]
+        temp_map[survey_region_pixels] = 1.0
+
+        # Resample temp_map to ensure that it matches the NSIDE parameter
+        # being used for the current simulation:
+        resampled_map = hp.ud_grade(temp_map, self.nside)
+
+        # Ensure designated pixels are not overriden:
+        indx = np.where((resampled_map > 0) & (self.pix_labels == ""))
+        self.pix_labels[indx] = label
+        for filtername in filter_ratios.keys():
+            self.healmaps[filtername][indx] = filter_ratios[filtername]
+
+    def load_star_density_data(limiting_mag=28.0):
+
+        MAP_DATA_DIR = get_data_dir()
+        data_file = path.join(MAP_DATA_DIR, 'TRIstarDensity_r_nside_64.npz')
+
+        if path.isfile(data_file):
+            npz_file = np.load(data_file)
+            with np.load(data_file) as npz_file:
+                star_map = npz_file['starDensity']
+                mag_bins = npz_file['bins']
+
+                dmag = abs(mag_bins - limiting_mag)
+                idx = np.where(dmag == dmag.min())[0]
+
+                star_density_map = np.copy(star_map[:,idx]).flatten()
+                star_density_map = hp.reorder(star_density_map, n2r=True)
+
+            return star_density_map
+
+        else:
+            raise IOError('Cannot find star density map data file at '+data_file)
+
+        return None
+
+    def rotateHealpix(hpmap, transf=['C','G'], phideg=0., thetadeg=0.):
+        """Rotates healpix map from one system to the other. Returns reordered healpy map.
+        Healpy coord transformations are used, or you can specify your own angles in degrees.
+        To specify your own angles, ensure that transf has length != 2.
+        Original code by Xiaolong Li
+        """
+
+        nside = hp.npix2nside(len(hpmap))
+
+        # Get theta, phi for non-rotated map
+        t,p = hp.pix2ang(nside, np.arange(hp.nside2npix(nside)))
+
+        # Define a rotator
+        if len(transf) == 2:
+            r = hp.Rotator(coord=transf)
+        else:
+            r = hp.Rotator(deg=True, rot=[phideg,thetadeg])
+
+        # Get theta, phi under rotated co-ordinates
+        trot, prot = r(t,p)
+
+        # Interpolate map onto these co-ordinates
+        rot_map = hp.get_interp_val(hpmap, trot, prot)
+
+        return rot_map
+
+    def return_maps(
+        self,
+        magellenic_clouds_ratios={"u": 0.32,"g": 0.4,"r": 1.0,"i": 1.0,"z": 0.9,"y": 0.9,},
+        scp_ratios={"u": 0.1, "g": 0.1, "r": 0.1, "i": 0.1, "z": 0.1, "y": 0.1},
+        nes_ratios={"g": 0.28, "r": 0.4, "i": 0.4, "z": 0.28},
+        dusty_plane_ratios={"u": 0.1,"g": 0.28, "r": 0.28,"i": 0.28,"z": 0.28,"y": 0.1,},
+        low_dust_ratios={"u": 0.32, "g": 0.4, "r": 1.0, "i": 1.0, "z": 0.9, "y": 0.9},
+        bulge_ratios={"u": 0.18, "g": 1.0, "r": 1.05, "i": 1.05, "z": 1.0, "y": 0.23},
+        virgo_ratios={"u": 0.32, "g": 0.4, "r": 1.0, "i": 1.0, "z": 0.9, "y": 0.9},
+
+        gal_plane = {"u": 0.18, "g": 1.0, "r": 1.05, "i": 1.05, "z": 1.0, "y": 0.23},
+        ):
+        # Array to hold the labels for each pixel
+        self.pix_labels = np.zeros(hp.nside2npix(self.nside), dtype="U20")
+        self.healmaps = np.zeros(
+            hp.nside2npix(self.nside),
+            dtype=list(zip(["u", "g", "r", "i", "z", "y"], [float] * 7)),
+        )
+
+        # Note, order here matters. Once a HEALpix is set and labled, subsequent add_ methods
+        # will not override that pixel.
+        self.add_gal_plane_region(self, filter_ratios)
+
+        self.add_magellanic_clouds(magellenic_clouds_ratios)
+        self.add_lowdust_wfd(low_dust_ratios)
+        self.add_virgo_cluster(virgo_ratios)
+        self.add_bulge(bulge_ratios)
+        self.add_nes(nes_ratios)
+        self.add_dusty_plane(dusty_plane_ratios)
+        self.add_scp(scp_ratios)
+
+        return self.healmaps, self.pix_labels


### PR DESCRIPTION
I've implemented the GalPlane survey footprint by reading in the pre-generated HEALpix maps.  

It seemed easiest to incorporate the alternative options for the pencilbeam fields by enabling this
code to read in the pre-generated map with the corresponding set of pencilbeams, so this is now
one of the optional parameters (pencilbeams={'small', 'alt'}. 

The other configurable parameter is the priority_threshold used to select a smaller/larger survey region
from the map.  

For the purposes of OpSim experiments, I recommend the following configurations be used:
priority_threshold, pencilbeams (comment)
0.3            small       (widest GP footprint, many small pencilbeams)
0.5            small       (medium GP footprint, many small pencilbeams)
0.8            small       (restricted GP footprint, many small pencilbeams)
0.5            alt            (medium GP footprint, fewer larger pencilbeams)

Please note that this implementation uses only the priority map for the i-band filter.  This is because of the filter-independent way that pixels are labeled in the handling of the maps by the attribute pix_labels.  Although this is a reasonable implementation for the purposes of this test, it should be noted that the Galactic Plane footprint differs significantly between filters, due to the impacts of spatially-variable extinction.  

It should also be noted that the Galactic Plane maps incorporate both the Magellanic Clouds and the Bulge, duplicating other existing methods. 